### PR TITLE
Connect pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,3 +11,5 @@ You should also add project tags for each release in Github, see [Managing relea
 - Add `doc_retriever` script for fetching articles from Media Cloud.
 - Modify `doc_retriever` script to store in Label Studio formatted Json.
 - Add `label_studio_uploader` script for uploading data to Label Studio.
+- Refactor parsing arguments in both `doc_retriever` and `label_studio_uploader`
+- Add `run_pipeline` script for connecting document-retrieval and label-studio-upload steps

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.9"
-
 services:
   mc_pipeline:
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
     volumes:
       - ./data:/app/data                 
 
-    entrypoint: ["python", "-m", "mc_classifier_pipeline.doc_retriever"]
+    entrypoint: ["python", "-m", "mc_classifier_pipeline.run_pipeline"]
     command: ["--help"]        
 
     # ports:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,7 @@ dev = [
 # The value must be of the form "<package_name>:<module_name>.<function>"
 [project.scripts]
 retrieve-mc-docs = "mc_classifier_pipeline.doc_retriever:main"
+mc-pipeline = "mc_classifier_pipeline.run_pipeline:main"
 
 # Add customizations to the Ruff linter as described on https://docs.astral.sh/ruff/configuration/
 [tool.ruff]

--- a/src/mc_classifier_pipeline/doc_retriever.py
+++ b/src/mc_classifier_pipeline/doc_retriever.py
@@ -164,7 +164,9 @@ def search_mediacloud_by_query(
                                 existing_article = json.load(f)
                                 articles.append(existing_article)
                         except Exception as e:
-                            logger.error(f"Error loading existing article {story_id}: {e}")
+                            logger.error(
+                                f"Error loading existing article {story_id}: {e}"
+                            )
                     continue
 
                 # Only fetch article data if not already retrieved
@@ -181,7 +183,11 @@ def search_mediacloud_by_query(
                     "text": article_data.get("text", ""),
                     "source": "mediacloud_query",
                     "retrieved_at": dt.datetime.now().isoformat(),
-                    "status": ArticleStatus.SUCCESS if article_data.get("text") else ArticleStatus.FAILED_NO_TEXT,
+                    "status": (
+                        ArticleStatus.SUCCESS
+                        if article_data.get("text")
+                        else ArticleStatus.FAILED_NO_TEXT
+                    ),
                     "story_id": story_id,
                     "publish_date": article_data.get("publish_date", ""),
                     "media_id": article_data.get("media_id", ""),
@@ -194,12 +200,17 @@ def search_mediacloud_by_query(
     except Exception as e:
         logger.error(f"Error searching Media Cloud: {e}")
 
-    logger.info(f"Processing complete: {new_articles} new articles, {existing_articles} existing articles")
+    logger.info(
+        f"Processing complete: {new_articles} new articles, {existing_articles} existing articles"
+    )
     return articles
 
 
 def save_articles_from_query(
-    articles: list, raw_articles_dir: Path, failed_urls_log: Path, articles_index: Optional[dict] = None
+    articles: list,
+    raw_articles_dir: Path,
+    failed_urls_log: Path,
+    articles_index: Optional[dict] = None,
 ):
     """
     Save articles retrieved from Media Cloud query to JSON files and update index.
@@ -262,7 +273,9 @@ def save_articles_from_query(
                 f.write(f"{url}\n")
         logger.info(f"Failed URLs logged to {failed_urls_log}")
 
-    logger.info(f"Saving complete. {new_articles} new articles saved, {len(failed_urls)} articles failed.")
+    logger.info(
+        f"Saving complete. {new_articles} new articles saved, {len(failed_urls)} articles failed."
+    )
 
 
 def analyze_search_results(articles: list):
@@ -296,11 +309,15 @@ def analyze_search_results(articles: list):
     for status, count in status_counts.items():
         logger.info(f"  {status}: {count}")
 
-    text_lengths = [len(article.get("text", "")) for article in articles if article.get("text")]
+    text_lengths = [
+        len(article.get("text", "")) for article in articles if article.get("text")
+    ]
     if text_lengths:
         logger.info("Text length statistics:")
         logger.info(f"  Mean: {sum(text_lengths) / len(text_lengths):.0f} characters")
-        logger.info(f"  Median: {sorted(text_lengths)[len(text_lengths) // 2]:.0f} characters")
+        logger.info(
+            f"  Median: {sorted(text_lengths)[len(text_lengths) // 2]:.0f} characters"
+        )
         logger.info(f"  Min: {min(text_lengths):.0f} characters")
         logger.info(f"  Max: {max(text_lengths):.0f} characters")
 
@@ -308,6 +325,7 @@ def analyze_search_results(articles: list):
     logger.info("Language breakdown:")
     for language, count in language_counts.items():
         logger.info(f"  {language}: {count}")
+
 
 def build_arg_parser(add_help: bool = True) -> argparse.ArgumentParser:
     """
@@ -332,31 +350,63 @@ def build_arg_parser(add_help: bool = True) -> argparse.ArgumentParser:
         """,
         add_help=add_help,
     )
-    parser.add_argument("--query", type=str, required=True, help="Search query for Media Cloud API")
+    parser.add_argument(
+        "--query", type=str, required=True, help="Search query for Media Cloud API"
+    )
 
     parser.add_argument("--output", type=Path, help="Optional: Output CSV file path")
 
     parser.add_argument(
-        "--raw-dir", type=Path, default=RAW_ARTICLES_DIR, help="Directory to store raw article JSON files"
+        "--raw-dir",
+        type=Path,
+        default=RAW_ARTICLES_DIR,
+        help="Directory to store raw article JSON files",
     )
-
-    parser.add_argument("--failed-log", type=Path, default=FAILED_URLS_LOG, help="Path to log failed URLs")
-
-    parser.add_argument("--index-file", type=Path, default=ARTICLES_INDEX_FILE, help="Path to articles index file")
-
-    parser.add_argument("--no-save-json", action="store_true", help="Skip saving individual JSON files")
 
     parser.add_argument(
-        "--force-reprocess", action="store_true", help="Force reprocessing of already retrieved articles"
+        "--failed-log",
+        type=Path,
+        default=FAILED_URLS_LOG,
+        help="Path to log failed URLs",
     )
-
-    parser.add_argument("--limit", type=int, default=100, help="Maximum number of results for query search")
 
     parser.add_argument(
-        "--start-date", required=True, type=str, help="Start date for query search (YYYY-MM-DD format)"
+        "--index-file",
+        type=Path,
+        default=ARTICLES_INDEX_FILE,
+        help="Path to articles index file",
     )
 
-    parser.add_argument("--end-date", required=True, type=str, help="End date for query search (YYYY-MM-DD format)")
+    parser.add_argument(
+        "--no-save-json", action="store_true", help="Skip saving individual JSON files"
+    )
+
+    parser.add_argument(
+        "--force-reprocess",
+        action="store_true",
+        help="Force reprocessing of already retrieved articles",
+    )
+
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=100,
+        help="Maximum number of results for query search",
+    )
+
+    parser.add_argument(
+        "--start-date",
+        required=True,
+        type=str,
+        help="Start date for query search (YYYY-MM-DD format)",
+    )
+
+    parser.add_argument(
+        "--end-date",
+        required=True,
+        type=str,
+        help="End date for query search (YYYY-MM-DD format)",
+    )
 
     # json formatted for label studio
     parser.add_argument(
@@ -367,6 +417,7 @@ def build_arg_parser(add_help: bool = True) -> argparse.ArgumentParser:
     )
 
     return parser
+
 
 def parse_arguments():
     """Parse command line arguments."""
@@ -414,11 +465,15 @@ def main(args):
         logger.error(f"Invalid date format: {e}. Use YYYY-MM-DD format.")
         return
 
-    articles = search_mediacloud_by_query(args.query, start_date, end_date, args.limit, articles_index, args.raw_dir)
+    articles = search_mediacloud_by_query(
+        args.query, start_date, end_date, args.limit, articles_index, args.raw_dir
+    )
 
     if articles:
         if not args.no_save_json:
-            save_articles_from_query(articles, args.raw_dir, args.failed_log, articles_index)
+            save_articles_from_query(
+                articles, args.raw_dir, args.failed_log, articles_index
+            )
             save_articles_index(articles_index, args.index_file)
         if args.output:
             logger.info("Creating output CSV...")
@@ -442,11 +497,17 @@ def main(args):
                 tasks.append({"data": data, "external_id": f"mc_story_{story_id}"})
 
             if not tasks:
-                logger.warning("No valid tasks to write, all articles were empty or invalid.")
+                logger.warning(
+                    "No valid tasks to write, all articles were empty or invalid."
+                )
             else:
-                with open(args.output_tasks_for_label_studio, "w", encoding="utf-8") as f:
+                with open(
+                    args.output_tasks_for_label_studio, "w", encoding="utf-8"
+                ) as f:
                     json.dump(tasks, f, ensure_ascii=False, indent=2)
-                logger.info(f"Label Studio task file saved to {args.output_tasks_for_label_studio}")
+                logger.info(
+                    f"Label Studio task file saved to {args.output_tasks_for_label_studio}"
+                )
 
         analyze_search_results(articles)
     else:

--- a/src/mc_classifier_pipeline/doc_retriever.py
+++ b/src/mc_classifier_pipeline/doc_retriever.py
@@ -309,9 +309,16 @@ def analyze_search_results(articles: list):
     for language, count in language_counts.items():
         logger.info(f"  {language}: {count}")
 
+def build_arg_parser(add_help: bool = True) -> argparse.ArgumentParser:
+    """
+    Build the argument parser for the Label Studio uploader.
 
-def parse_arguments():
-    """Parse command line arguments."""
+    Args:
+        add_help: Whether to add the default help argument
+
+    Returns:
+        Argument parser instance
+    """
     parser = argparse.ArgumentParser(
         description="Media Cloud query search and article processing pipeline with persistent tracking",
         formatter_class=argparse.RawDescriptionHelpFormatter,
@@ -323,6 +330,7 @@ def parse_arguments():
             python -m mc_classifier_pipeline.doc_retriever --query "election" --start-date 2024-12-01 --end-date 2024-12-31 --limit 50 --output-tasks-for-label-studio data/labelstudio_tasks.json
 
         """,
+        add_help=add_help,
     )
     parser.add_argument("--query", type=str, required=True, help="Search query for Media Cloud API")
 
@@ -358,17 +366,22 @@ def parse_arguments():
         default=None,
     )
 
-    return parser.parse_args()
+    return parser
+
+def parse_arguments():
+    """Parse command line arguments."""
+    return build_arg_parser().parse_args()
 
 
-def main():
+def main(args):
     """
     Main function to run the Media Cloud query search and article processing pipeline.
     This function parses command-line arguments, loads a persistent index of articles,
     searches Media Cloud for new articles based on a query, saves the results,
     and provides a summary analysis.
     """
-    args = parse_arguments()
+    if args is None:
+        args = parse_arguments()
 
     # Default to output Label Studio Json if not specified
     default_label_studio_path = Path("data/labelstudio_tasks.json")

--- a/src/mc_classifier_pipeline/label_studio_uploader.py
+++ b/src/mc_classifier_pipeline/label_studio_uploader.py
@@ -45,9 +45,10 @@ def upload_tasks(tasks: list, project_id: int, label_studio_host: str, label_stu
         logger.error("Upload failed (%s): %s", response.status_code, response.text)
         raise requests.RequestException(f"Upload failed with response {response.status_code}: {response.text}")
 
-
-def parse_args():
-    """Parse command line arguments."""
+def build_uploader_parser(add_help=True):
+    """
+    Build the argument parser for the Label Studio uploader.
+    """
 
     parser = argparse.ArgumentParser(
         description="Upload formatted Label Studio tasks JSON to a specified Label Studio project via API.",
@@ -59,6 +60,7 @@ def parse_args():
             # Upload a custom tasks file to Label Studio project with id 100
             python src/mc_classifier_pipeline/label_studio_uploader.py data/custom_tasks.json -p 100
         """,
+        add_help=add_help,
     )
 
     parser.add_argument(
@@ -75,11 +77,16 @@ def parse_args():
         required=True,
         help="The project id for the Label Studio project where tasks will be added",
     )
-    return parser.parse_args()
+    return parser
+
+def parse_args():
+    """Parse command line arguments."""
+    return build_uploader_parser().parse_args()
 
 
-def main():
-    args = parse_args()
+def main(args):
+    if args is None:
+        args = parse_args()
     label_studio_host = os.getenv("LABEL_STUDIO_HOST")
     label_studio_token = os.getenv("LABEL_STUDIO_TOKEN")
     missing_vars = []

--- a/src/mc_classifier_pipeline/label_studio_uploader.py
+++ b/src/mc_classifier_pipeline/label_studio_uploader.py
@@ -45,9 +45,15 @@ def upload_tasks(tasks: list, project_id: int, label_studio_host: str, label_stu
         logger.error("Upload failed (%s): %s", response.status_code, response.text)
         raise requests.RequestException(f"Upload failed with response {response.status_code}: {response.text}")
 
-def build_uploader_parser(add_help=True):
+def build_uploader_parser(add_help=True) -> argparse.ArgumentParser:
     """
     Build the argument parser for the Label Studio uploader.
+    
+    Args:
+        add_help: Whether to add the default help argument
+
+    Returns:
+        Argument parser instance
     """
 
     parser = argparse.ArgumentParser(

--- a/src/mc_classifier_pipeline/run_pipeline.py
+++ b/src/mc_classifier_pipeline/run_pipeline.py
@@ -9,8 +9,6 @@ from __future__ import annotations
 
 import argparse
 import logging
-import os
-from pathlib import Path
 
 from .utils import configure_logging
 from . import doc_retriever as dr

--- a/src/mc_classifier_pipeline/run_pipeline.py
+++ b/src/mc_classifier_pipeline/run_pipeline.py
@@ -1,26 +1,27 @@
 """
 End-to-end pipeline:
-  1. Query documents → JSON tasks
+  1. Query documents -> JSON tasks
   2. Push those tasks to a chosen Label Studio project
 Usage example:
-  python run_pipeline.py --query "election" --start 2025-06-01 --end 2025-06-30 --project_id 2
+  python -m mc_classifier_pipeline.run_pipeline.py --query "election" --start 2025-06-01 --end 2025-06-30 --project_id 2
 """
+
 from __future__ import annotations
 
 import argparse
 import logging
 
-from .utils import configure_logging
-from . import doc_retriever as dr
-from . import label_studio_uploader as lsu
+from mc_classifier_pipeline.utils import configure_logging
+import mc_classifier_pipeline.doc_retriever as dr
+import mc_classifier_pipeline.label_studio_uploader as lsu
 
 configure_logging()
 logger = logging.getLogger(__name__)
-    
-    
+
+
 def parse_cli():
     parser = argparse.ArgumentParser(
-        description="End-to-end MediaCloud ➜ Label Studio pipeline",
+        description="End-to-end MediaCloud -> Label Studio pipeline",
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
         parents=[
             dr.build_arg_parser(add_help=False),
@@ -30,7 +31,7 @@ def parse_cli():
     logger.info("Parsed command line arguments...")
     return parser.parse_args()
 
-    
+
 def main() -> None:  # entry‑point in pyproject.toml
     args = parse_cli()
 
@@ -43,5 +44,5 @@ def main() -> None:  # entry‑point in pyproject.toml
     lsu.main(args)
 
 
-if __name__ == "__main__": 
+if __name__ == "__main__":
     main()

--- a/src/mc_classifier_pipeline/run_pipeline.py
+++ b/src/mc_classifier_pipeline/run_pipeline.py
@@ -20,9 +20,11 @@ logger = logging.getLogger(__name__)
 
 
 def parse_cli():
+    # Create the main argument parser for the pipeline
     parser = argparse.ArgumentParser(
         description="End-to-end MediaCloud -> Label Studio pipeline",
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+        # Use argument parsers from doc_retriever and label_studio_uploader as parents
         parents=[
             dr.build_arg_parser(add_help=False),
             lsu.build_uploader_parser(add_help=False),

--- a/src/mc_classifier_pipeline/run_pipeline.py
+++ b/src/mc_classifier_pipeline/run_pipeline.py
@@ -1,0 +1,49 @@
+"""
+End-to-end pipeline:
+  1. Query documents → JSON tasks
+  2. Push those tasks to a chosen Label Studio project
+Usage example:
+  python run_pipeline.py --query "election" --start 2025-06-01 --end 2025-06-30 --project_id 2
+"""
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+from pathlib import Path
+
+from .utils import configure_logging
+from . import doc_retriever as dr
+from . import label_studio_uploader as lsu
+
+configure_logging()
+logger = logging.getLogger(__name__)
+    
+    
+def parse_cli():
+    parser = argparse.ArgumentParser(
+        description="End-to-end MediaCloud ➜ Label Studio pipeline",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+        parents=[
+            dr.build_arg_parser(add_help=False),
+            lsu.build_uploader_parser(add_help=False),
+        ],
+    )
+    logger.info("Parsed command line arguments...")
+    return parser.parse_args()
+
+    
+def main() -> None:  # entry‑point in pyproject.toml
+    args = parse_cli()
+
+    # Retrieve articles & build JSON file
+    logger.info("Running doc_retriever step")
+    dr.main(args)
+
+    # Upload tasks to Label Studio
+    logger.info("Running label_studio_uploader step")
+    lsu.main(args)
+
+
+if __name__ == "__main__": 
+    main()


### PR DESCRIPTION
### Major Changes
- Added `run_pipeline.py` to orchestrate the full pipeline with a unified CLI.
- Refactored argument parsing in both `doc_retriever.py` and `label_studio_uploader.py` into reusable functions so that `run_pipeline.py` could combine and share CLI arguments from both modules in a unified interface.
-  Updated `pyproject.toml`, `docker_compose.yml` and `CHANGELOG.md` to reflect the changes.


### Example usage
- docker compose build
- docker compose run --rm mc_pipeline --query "election" --start-date 2024-12-01 --end-date 2024-12-31 -p 1

P.S. Remember to change LABEL_STUDIO_HOST to http://host.docker.internal:8080 in you .env file